### PR TITLE
Add common cookie support for wg_cid

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 There are two types of events that Webgains tag supports: PageView and Conversion. 
 
-- **PageView event** stores the cid URL parameter inside the wg_cid cookie. 
+- **PageView event** stores the cid URL parameter inside the `wg_cid` cookie. 
 - **Conversion event** sends the HTTP request with the specified conversion data to Webgains.
 
-## How to use the Webgains tag:
+## How to use the Webgains tag
 
 1. Create a Webgains tag and add Page View and Purchase triggers
 2. Add the only required field for the conversion event - Program ID, other fields are optional.
@@ -14,7 +14,7 @@ There are two types of events that Webgains tag supports: PageView and Conversio
 
 **Order Reference** - Unique ID that identifies the order or transaction on your site.
 
-**Event ID** - Event id.
+**Event ID** - Event ID.
 
 **Currency** - Transaction currency.
 
@@ -24,14 +24,13 @@ There are two types of events that Webgains tag supports: PageView and Conversio
 
 **Location** - Checkout URL. May remain empty.
 
-**Click id** - Value of the identifier. This value must be the click ID assigned to the user.
+**Click ID** - Value of the identifier. This value must be the Click ID assigned to the user.
 
 **Comment** - Optional commentary.
 
 **Items** - Array with the articles of the transaction.
 
 **Item Fields** - Array with the fields of the articles.
-
 
 ## Open Source
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,7 @@
 homepage: 'https://stape.io/'
 versions:
+  - sha: aae6f27d3c68566006541470708b65f877f55fdc
+    changeNotes: Add common cookie support for Click ID cookie.
   - sha: 9617ec1416bb4c1181e0c587c1c5359dd757b126
     changeNotes: Making httpOnly optional for cookie.
   - sha: 25fa847eaeacf0ed9b412acfcefb8f08024b1413

--- a/template.js
+++ b/template.js
@@ -47,8 +47,11 @@ function handlePageViewEvent() {
 }
 
 function handleConversionEvent() {
-  const clickId = data.clickId || getCookieValues('wg_cid')[0];
+  const commonCookie = eventData.common_cookie || {};
+  const clickId = data.clickId || getCookieValues('wg_cid')[0] || commonCookie.wg_cid;
+  
   if (!clickId) return data.gtmOnSuccess();
+  
   const payload = getRequestPayload(clickId);
   const requestUrl = 'https://api.webgains.io/queue-conversion';
   if (isLoggingEnabled) {
@@ -137,7 +140,7 @@ function getItems() {
     price: item[itemFields.price || 'price'] || 0,
     name: item[itemFields.name || 'item_name'] || '',
     code: item[itemFields.code || 'item_id'] || '',
-    voucher: item[itemFields.voucher || 'coupon'] || ''
+    voucher: item[itemFields.voucher || 'voucher'] || ''
   }));
 }
 

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-﻿___TERMS_OF_SERVICE___
+___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-___TERMS_OF_SERVICE___
+﻿___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at
@@ -311,8 +311,11 @@ function handlePageViewEvent() {
 }
 
 function handleConversionEvent() {
-  const clickId = data.clickId || getCookieValues('wg_cid')[0];
+  const commonCookie = eventData.common_cookie || {};
+  const clickId = data.clickId || getCookieValues('wg_cid')[0] || commonCookie.wg_cid;
+  
   if (!clickId) return data.gtmOnSuccess();
+  
   const payload = getRequestPayload(clickId);
   const requestUrl = 'https://api.webgains.io/queue-conversion';
   if (isLoggingEnabled) {
@@ -710,5 +713,3 @@ scenarios: []
 ___NOTES___
 
 Created on 25/03/2024, 15:44:08
-
-

--- a/template.tpl
+++ b/template.tpl
@@ -151,9 +151,9 @@ ___TEMPLATE_PARAMETERS___
           {
             "type": "TEXT",
             "name": "clickId",
-            "displayName": "Click id",
+            "displayName": "Click ID",
             "simpleValueType": true,
-            "help": "Value of the identifier. This value must be the click ID assigned to the user.\n\u003cbr/\u003e\nDefault: cid param previously saved to \u003cb\u003ewg_cid\u003c/b\u003e cookie."
+            "help": "Value of the identifier. This value must be the Click ID assigned to the user.\n<br/>\nDefault: <b>cid</b> URL param value previously saved to <b>wg_cid</b> cookie, with fallback to <b>common_cookie.wg_cid</b> in the Event Data object passed to Stape's Data Tag."
           },
           {
             "type": "TEXT",


### PR DESCRIPTION
Hi.

The Data Tag is being modified (PR not done yet) to support the `wg_cid` cookie (Click ID) on the `common_cookie` object.

The objective of this update is to check this property also when reading the Click ID value before sending it on the request.

I have also noticed that the template.js was not synchronized with the `template.tpl`. You can see that [here](https://github.com/giovaniortolani/webgains-tag/commit/3a5173c4c1d7b96b1ebc78d78f9cb2cff452916b#diff-4cae99d1fcdb3624d25cd68a3151a48e7d6b3bc1047c61bff8fe3cde95917210R143).